### PR TITLE
fix(install): no lint errors out of the box

### DIFF
--- a/extension/src/templates/noprettier/_eslintrc.js
+++ b/extension/src/templates/noprettier/_eslintrc.js
@@ -45,7 +45,9 @@ module.exports = {
     ga: true, // Google Analytics
     cordova: true,
     __statics: true,
-    process: true
+    process: true,
+    module: true,
+    require: true
   },
 
   // add your custom rules here
@@ -53,6 +55,7 @@ module.exports = {
     'prefer-promise-reject-errors': 'off',
     quotes: ['warn', 'single'],
     '@typescript-eslint/indent': ['warn', 2],
+    '@typescript-eslint/camelcase': 'off',
 
     // allow console.log during development only
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',

--- a/extension/src/templates/prettier/_eslintrc.js
+++ b/extension/src/templates/prettier/_eslintrc.js
@@ -51,7 +51,9 @@ module.exports = {
     ga: true, // Google Analytics
     cordova: true,
     __statics: true,
-    process: true
+    process: true,
+    module: true,
+    require: true
   },
 
   // add your custom rules here
@@ -59,6 +61,7 @@ module.exports = {
     'prefer-promise-reject-errors': 'off',
     quotes: ['warn', 'single'],
     '@typescript-eslint/indent': ['warn', 2],
+    '@typescript-eslint/camelcase': 'off',
 
     // allow console.log during development only
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',


### PR DESCRIPTION
Fixes #31

```
babel.config.js
  1:1  error  'module' is not defined  no-undef

quasar.conf.js
    4:1   error    'module' is not defined                             no-undef
    4:28  warning  'ctx' is defined but never used                     @typescript-eslint/no-unused-vars
   82:24  error    'require' is not defined                            no-undef
  110:9   error    Identifier 'background_color' is not in camel case  @typescript-eslint/camelcase
  111:9   error    Identifier 'theme_color' is not in camel case       @typescript-eslint/camelcase
  150:22  warning  'cfg' is defined but never used                     @typescript-eslint/no-unused-vars

```