### PR TITLE
Fix install when use npm

### DIFF
--- a/extension/src/install.js
+++ b/extension/src/install.js
@@ -182,11 +182,18 @@ sourceFiles: {
 
   // TODO: detect if npm or yarn was used
   // TODO: some files need typings for theirs parameters (eg. axios and i18n boot files)
-  execa('yarn').then(() =>
+
+  if (api.prompts.packageManager === 'npm') {
+    execa('npm', ['run', 'lint', '--fix']).catch(() => {
+      // We'll always get some lint errors until we switch all files to ES6 syntax
+      //  or programmatically add `eslint-env node` around and `eslint-disable-next-line` for
+      //  problematic points
+    })
+  } else {
     execa('yarn', ['lint', '--fix']).catch(() => {
       // We'll always get some lint errors until we switch all files to ES6 syntax
       //  or programmatically add `eslint-env node` around and `eslint-disable-next-line` for
       //  problematic points
     })
-  )
+  }
 }

--- a/extension/src/prompts.js
+++ b/extension/src/prompts.js
@@ -10,6 +10,22 @@
 module.exports = function() {
   return [
     {
+      name: 'packageManager',
+      type: 'list',
+      required: true,
+      message: 'Please choose your package manager:',
+      choices: [
+        {
+          name: 'NPM',
+          value: 'npm'
+        },
+        {
+          name: 'Yarn',
+          value: 'yarn'
+        }
+      ]
+    },
+    {
       name: 'webpack',
       type: 'list',
       required: true,


### PR DESCRIPTION
The yarn command in install.js make a error when you don't use yarn or don't have yarn installed.

Maybe related: https://github.com/quasarframework/app-extension-typescript/issues/35