### PR TITLE
perf: Avoid affecting script tags that have been marked as ts.

### DIFF
--- a/extension/src/install.js
+++ b/extension/src/install.js
@@ -265,7 +265,7 @@ async function updateCode(api) {
     let text = fs.readFileSync(file, 'utf8')
 
     text = text.replace(/<script.*>/, (tag) => {
-      tag = tag.replace(/lang="(js|javascript)" ?/, '')
+      tag = tag.replace(/lang="(js|javascript|ts)" ?/, '')
       tag = tag.replace(/src="(.*)\.js"/, (tag, fileName) => {
         // Record that file exports a Vue instance
         vueComponentScriptFiles.push(path.join(fileDir, fileName + '.js'))


### PR DESCRIPTION
Avoid affecting script tags that have been marked as ts.
For example, <script lang = "ts" /> will be changed to <script lang = "ts" lang = "ts" />